### PR TITLE
Set global coverage thresholds in Jest configuration

### DIFF
--- a/Docs/5-so-what.md
+++ b/Docs/5-so-what.md
@@ -91,3 +91,23 @@ In the coverage directory you will find a browsable report.
 
 ## Some files don't have coverage.  So what?
 
+We can add a coverage threshold to the config.js file
+
+```js
+  coverageThreshold: {
+    global: {
+      branches: 80, // Require 80% of branch coverage
+      functions: 80, // Require 80% of function coverage
+      lines: 80, // Require 80% of line coverage
+      statements: 80, // Require 80% of statement coverage
+    },
+  },
+```
+
+We add a coverage threshold and rerun the tests and we get these results:
+
+```
+Jest: "global" coverage threshold for statements (80%) not met: 77.63%
+Jest: "global" coverage threshold for lines (80%) not met: 77.63%
+Jest: "global" coverage threshold for functions (80%) not met: 60%
+```

--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -36,6 +36,14 @@ const config = {
     '<rootDir>/src', // Allows imports from the src directory without relative paths
   ],
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/'}),
+  coverageThreshold: {
+    global: {
+      branches: 80, // Require 80% of branch coverage
+      functions: 80, // Require 80% of function coverage
+      lines: 80, // Require 80% of line coverage
+      statements: 80, // Require 80% of statement coverage
+    },
+  },
 };
 
 module.exports = config;


### PR DESCRIPTION
Added a `coverageThreshold` property to enforce 80% minimum coverage for branches, functions, lines, and statements in the Jest config. Updated the documentation to reflect this change and tested the setup, revealing areas falling below the threshold.