### PR TITLE
Add Husky for pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
         "dotenv-cli": "^8.0.0",
+        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-mock-extended": "^4.0.0-beta1",
         "prettier": "3.4.2",
@@ -3347,6 +3348,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:watch": "jest --watch --config jest.unit.config.js",
     "integration-testing:setup": "./integration-teseting-setup.sh",
     "integration-testing:teardown": "docker compose -f docker-compose.test.yml down",
-    "integration-test": "npm run integration-testing:setup && jest --config jest.integration.config.js || true && npm run integration-testing:teardown"
+    "integration-test": "npm run integration-testing:setup && jest --config jest.integration.config.js || true && npm run integration-testing:teardown",
+    "prepare": "husky"
   },
   "keywords": [],
   "author": "",
@@ -30,6 +31,7 @@
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
     "dotenv-cli": "^8.0.0",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-mock-extended": "^4.0.0-beta1",
     "prettier": "3.4.2",

--- a/tests/unit/validators/actor.validator.unit.spec.ts
+++ b/tests/unit/validators/actor.validator.unit.spec.ts
@@ -25,7 +25,7 @@ describe('ActorValidator - createActorSchema', () => {
       const zodError = error as ZodError;
       expect(zodError.issues).toEqual([
         {
-          code: 'invalid_type!', // Zod error code
+          code: 'invalid_type', // Zod error code
           expected: 'string', // Expected field type
           received: 'undefined', // What Zod received instead
           path: ['first_name'], // The path where the error occurred


### PR DESCRIPTION
Introduce Husky to automate pre-commit hooks, starting with running `npm test` on each commit. Updated dependencies and added the necessary configuration in the package.json to ensure proper setup.